### PR TITLE
feat(opencode): add opencode configuration

### DIFF
--- a/home/.chezmoidata/macos/packages.yaml
+++ b/home/.chezmoidata/macos/packages.yaml
@@ -33,6 +33,7 @@ packages:
           - docker
           - wget
           - gnu-tar
+          - opencode
         personal:
           - ffmpeg
         work:

--- a/home/dot_config/opencode/AGENTS.md
+++ b/home/dot_config/opencode/AGENTS.md
@@ -1,0 +1,44 @@
+# Agent Guidelines
+
+## General Rules
+
+- When asked to analyze or suggest changes, do NOT edit files unless explicitly asked to. Analysis-only requests should produce only text output.
+- Use American English spelling (e.g., "color" not "colour", "organize" not "organise").
+
+## Coding style
+
+- Only add comments to tricky, hard to follow parts of the code.
+- Do not add comments for simple logic. Extract it to variables/functions, use naming to communicate intention.
+
+## Git
+
+### Commits
+
+- When making commits, only include changes directly related to the task. Never commit unrelated formatting or whitespace changes alongside feature changes.
+- When user says 'commit and push' or 'open a PR', execute directly without extra exploration or test runs unless explicitly asked. Keep the workflow fast.
+
+### Branches
+
+- When creating git branches, always prefix with "florent.clarret/" (e.g., "florent.clarret/feature-branch-name"). The feature-branch-name should be descriptive of the work being done in the branch (e.g., "florent.clarret/add-new-api-endpoint").
+- When creating git branches, always create them from the main branch. Always make sure to pull the latest changes from the main branch before creating a new branch to ensure that your branch is up to date with the latest codebase. This helps to minimize merge conflicts and ensures that your work is based on the most recent version of the code.
+
+### Pushing
+
+- Never use `git push` without specifying the branch. Always push one branch at a time using `git push origin <branch-name>`.
+- Never use `git push --force` or `git push -f`.
+
+### Commit Messages
+
+- Be concise — get straight to the point, no fluff.
+- You can add a description after the first line if necessary, but keep it brief and relevant.
+
+## Pull Requests
+
+### General PR Guidelines
+
+- Always open the Pull Requests as drafts.
+- If there's a PR template, always follow it.
+- If relevant, always put examples what the code is doing in the PR description. For example, if we're adding a script, add an example of how to run it and what the expected output is.
+- Don't mention CI-covered items (building, linting, tests passing)
+- NEVER merge any PR without explicit approval from me
+- Always use markdown hyperlinks in PR bodies ([Description](url) not bare URLs)

--- a/home/dot_config/opencode/opencode.json
+++ b/home/dot_config/opencode/opencode.json
@@ -1,0 +1,3 @@
+{
+  "$schema": "https://opencode.ai/config.json"
+}

--- a/home/dot_oh-my-zsh/custom/opencode.zsh
+++ b/home/dot_oh-my-zsh/custom/opencode.zsh
@@ -1,0 +1,29 @@
+#!/usr/bin/env zsh
+
+#compdef opencode
+###-begin-opencode-completions-###
+#
+# yargs command completion script
+#
+# Installation: opencode completion >> ~/.zshrc
+#    or opencode completion >> ~/.zprofile on OSX.
+#
+_opencode_yargs_completions()
+{
+  local reply
+  local si=$IFS
+  IFS=$'
+' reply=($(COMP_CWORD="$((CURRENT-1))" COMP_LINE="$BUFFER" COMP_POINT="$CURSOR" opencode --get-yargs-completions "${words[@]}"))
+  IFS=$si
+  if [[ ${#reply} -gt 0 ]]; then
+    _describe 'values' reply
+  else
+    _default
+  fi
+}
+if [[ "'${zsh_eval_context[-1]}" == "loadautofunc" ]]; then
+  _opencode_yargs_completions "$@"
+else
+  compdef _opencode_yargs_completions opencode
+fi
+###-end-opencode-completions-###


### PR DESCRIPTION
## Summary

- Adds opencode configuration file at `~/.config/opencode/opencode.json`
- Adds AGENTS.md with agent guidelines at `~/.config/opencode/AGENTS.md`
- Adds zsh completions for opencode at `~/.oh-my-zsh/custom/opencode.zsh`
- Adds opencode to macOS packages list

## Files

| File | Description |
|------|-------------|
| `home/dot_config/opencode/opencode.json` | Empty config with schema |
| `home/dot_config/opencode/AGENTS.md` | Agent guidelines (rules, git, PR) |
| `home/dot_oh-my-zsh/custom/opencode.zsh` | Zsh tab completions for opencode |
| `home/.chezmoidata/macos/packages.yaml` | Adds opencode to Homebrew packages |