### PR TITLE
feat(opencode): convert config to templates for work/personal support

### DIFF
--- a/home/.chezmoiignore
+++ b/home/.chezmoiignore
@@ -12,6 +12,7 @@ Library
 
 {{ if .personal }}
 .claude
+.config/opencode/dd.json
 
 .config/git/gitconfig-work.toml
 

--- a/home/dot_config/opencode/dd.json
+++ b/home/dot_config/opencode/dd.json
@@ -1,0 +1,17 @@
+{
+  "claude": {
+    "agents": { "sync": true },
+    "commands": { "sync": true },
+    "env": { "sync": true },
+    "skills": { "sync": true }
+  },
+  "gateway": {
+    "anthropic": { "enabled": true },
+    "google": { "enabled": true },
+    "openai": { "enabled": true }
+  },
+  "appgate": true,
+  "aiguard": {
+    "enabled": false
+  }
+}

--- a/home/dot_config/opencode/opencode.json
+++ b/home/dot_config/opencode/opencode.json
@@ -1,3 +1,0 @@
-{
-  "$schema": "https://opencode.ai/config.json"
-}

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "share": "disabled",
+  "permission": {
+    "edit": "ask",
+    "webfetch": "ask",
+    "doom_loop": "ask",
+    "external_directory": "ask",
+    "bash": {
+      "*": "ask",
+      "pwd": "allow",
+      "git status": "allow",
+      "git log *": "allow",
+      "git show *": "allow",
+      "git diff *": "allow",
+      "git blame *": "allow",
+      "gh pr view *": "allow",
+      "grep *": "allow",
+      "rg *": "allow",
+      "ls *": "allow",
+      "tail *": "allow",
+      "head *": "allow",
+      "cat *": "allow"
+    }
+  }
+  {{- if .work }}
+  ,"disabled_providers": ["opencode"]
+  ,"plugin": ["git@github.com:DataDog/opencode-datadog.git"]
+  ,"mcp": {
+    "atlassian": {
+      "type": "remote",
+      "url": "https://mcp.atlassian.com/v1/sse"
+    },
+    "datadog": {
+      "type": "remote",
+      "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core,software-delivery"
+    },
+  }
+  {{- end -}}
+}

--- a/home/dot_config/opencode/tui.json.tmpl
+++ b/home/dot_config/opencode/tui.json.tmpl
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://opencode.ai/tui.json"
+  {{- if .work }}
+  ,"plugin": ["git@github.com:DataDog/opencode-datadog.git"]
+  {{- end }}
+}


### PR DESCRIPTION
## Summary

- Replace `opencode.json` with `opencode.json.tmpl` to conditionally enable work-specific providers, plugins, and MCP servers ([Atlassian](https://mcp.atlassian.com) and [Datadog](https://mcp.datadoghq.com))
- Add `dd.json` for Datadog MCP gateway configuration (ignored on personal machines via `.chezmoiignore`)
- Add `tui.json.tmpl` for TUI config with work-specific plugin

## Details

The `opencode.json.tmpl` template uses the `{{ if .work }}` chezmoi condition to toggle:
- Disabled providers (disables the default `opencode` provider on work machines)
- Work-specific plugins
- MCP servers for Atlassian and Datadog integrations

The `dd.json` file holds the Datadog MCP gateway config and is excluded from personal machines since it's not relevant there.