### PR TITLE
docs(agents): update PR description when pushing to existing PR

### DIFF
--- a/home/dot_config/opencode/AGENTS.md
+++ b/home/dot_config/opencode/AGENTS.md
@@ -42,3 +42,4 @@
 - Don't mention CI-covered items (building, linting, tests passing)
 - NEVER merge any PR without explicit approval from me
 - Always use markdown hyperlinks in PR bodies ([Description](url) not bare URLs)
+- When pushing new commits to an existing PR, update the PR description to reflect the latest changes using `gh pr edit`.


### PR DESCRIPTION
## Summary

- Add a guideline to `AGENTS.md` requiring the PR description to be updated via `gh pr edit` whenever new commits are pushed to an existing PR.