### PR TITLE
docs(agents): update PR description when pushing new commits

### DIFF
--- a/home/dot_config/opencode/AGENTS.md
+++ b/home/dot_config/opencode/AGENTS.md
@@ -42,3 +42,4 @@
 - Don't mention CI-covered items (building, linting, tests passing)
 - NEVER merge any PR without explicit approval from me
 - Always use markdown hyperlinks in PR bodies ([Description](url) not bare URLs)
+- When pushing new commits to an existing PR, update the PR description to reflect the latest changes using `gh pr edit`.

--- a/home/dot_config/opencode/opencode.json.tmpl
+++ b/home/dot_config/opencode/opencode.json.tmpl
@@ -34,7 +34,7 @@
     "datadog": {
       "type": "remote",
       "url": "https://mcp.datadoghq.com/api/unstable/mcp-server/mcp?toolsets=core,software-delivery"
-    },
+    }
   }
-  {{- end -}}
+  {{- end }}
 }


### PR DESCRIPTION
## Changes

- Add agent guideline to update PR description when pushing new commits to an existing PR
- Fix trailing comma in `opencode.json.tmpl` (invalid JSON) and template whitespace